### PR TITLE
show an error dialog when WiFi PSK incorrect

### DIFF
--- a/plugins/dhcpcd-gtk/main.c
+++ b/plugins/dhcpcd-gtk/main.c
@@ -49,6 +49,9 @@ static NotifyNotification *nn;
 
 static gboolean dhcpcd_try_open(gpointer data);
 static gboolean dhcpcd_wpa_try_open(gpointer data);
+extern void
+wpa_show_err(const char *title, const char *txt, DHCPCDUIPlugin *dhcp);
+
 
 void set_icon (LXPanel *p, GtkWidget *image, const char *icon, int size)
 {
@@ -687,6 +690,14 @@ dhcpcd_wpa_scan_cb(DHCPCD_WPA *wpa, gpointer p)
     }
 }
 
+
+static void
+dhcpcd_wpa_error_cb(DHCPCD_WPA *wpa, gpointer p)
+{
+    DHCPCDUIPlugin * dhcp = (DHCPCDUIPlugin *) p;
+    wpa_show_err(_("Error Connecting"),_("There was an error connecting to the wifi network. Check your selected network and key and try again."),dhcp);
+}
+
 static void
 dhcpcd_wpa_status_cb(DHCPCD_WPA *wpa,
     unsigned int status, const char *status_msg, gpointer p)
@@ -848,6 +859,7 @@ static GtkWidget *dhcpcdui_constructor (LXPanel *panel, config_setting_t *settin
     dhcpcd_set_status_callback (dhcp->con, dhcpcd_status_cb, dhcp);
     dhcpcd_set_if_callback (dhcp->con, dhcpcd_if_cb, dhcp);
     dhcpcd_wpa_set_scan_callback (dhcp->con, dhcpcd_wpa_scan_cb, dhcp);
+    dhcpcd_wpa_set_error_callback(dhcp->con, dhcpcd_wpa_error_cb, dhcp);
     dhcpcd_wpa_set_status_callback (dhcp->con, dhcpcd_wpa_status_cb, dhcp);
     if (dhcpcd_try_open (dhcp))
         dhcp->reopen_timer = g_timeout_add (DHCPCD_RETRYOPEN, dhcpcd_try_open, dhcp);

--- a/plugins/dhcpcd-gtk/wpa.c
+++ b/plugins/dhcpcd-gtk/wpa.c
@@ -29,8 +29,7 @@
 #include "dhcpcd-gtk.h"
 
 //static GtkWidget *wpa_dialog, *wpa_err;
-
-static void
+void
 wpa_show_err(const char *title, const char *txt, DHCPCDUIPlugin *dhcp)
 {
 

--- a/plugins/libdhcpcd/dhcpcd.h
+++ b/plugins/libdhcpcd/dhcpcd.h
@@ -197,6 +197,8 @@ typedef struct dhcpcd_wi_hist {
 typedef struct dhcpcd_wpa {
 	struct dhcpcd_wpa *next;
 	char ifname[IF_NAMESIZE];
+	char userconnect_ssid[IF_SSIDSIZE];
+	char connect_ssid[IF_SSIDSIZE];
 	unsigned int status;
 	int command_fd;
 	char *command_path;
@@ -227,6 +229,8 @@ typedef struct dhcpcd_connection {
 	bool wpa_started;
 	void (*wi_scanresults_cb)(DHCPCD_WPA *, void *);
 	void *wi_scanresults_context;
+	void (*wi_error_cb)(DHCPCD_WPA *, void *);
+	void *wi_error_context;
 	void (*wpa_status_cb)(DHCPCD_WPA *, unsigned int, const char *, void *);
 	void *wpa_status_context;
 
@@ -300,6 +304,10 @@ DHCPCD_IF *dhcpcd_wpa_if(DHCPCD_WPA *);
 void dhcpcd_wpa_if_event(DHCPCD_IF *);
 void dhcpcd_wpa_set_scan_callback(DHCPCD_CONNECTION *,
     void (*)(DHCPCD_WPA *, void *), void *);
+ void
+dhcpcd_wpa_set_error_callback(DHCPCD_CONNECTION *con,
+    void (*cb)(DHCPCD_WPA *, void *), void *context);
+
 void dhcpcd_wpa_set_status_callback(DHCPCD_CONNECTION *,
     void (*)(DHCPCD_WPA *, unsigned int, const char *, void *), void *);
 int dhcpcd_wi_scan_compare(DHCPCD_WI_SCAN *a, DHCPCD_WI_SCAN *b);


### PR DESCRIPTION
When connect to AP, if WiFi PSK is more than 7 charactors and incorrect, there is no prompt on the UI. User does not know what happened