### PR TITLE
Fix a missing in "switch-case" when parsing string

### DIFF
--- a/plugins/libdhcpcd/dhcpcd.c
+++ b/plugins/libdhcpcd/dhcpcd.c
@@ -381,6 +381,7 @@ dhcpcd_decode_string_escape(char *dst, size_t dlen, const char *src)
 			case '\\':
 			case '0':
 			case '1':
+			case '2':
 			case '3':
 			case '4':
 			case '5':


### PR DESCRIPTION
Lost a case '2'